### PR TITLE
Fix proposal approval based on cosmos design

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -2,9 +2,7 @@ use crate::msg::{
     AllCombinationResponse, AllWinnerResponse, CombinationInfo, ConfigResponse, GetPollResponse,
     HandleMsg, InitMsg, QueryMsg, RoundResponse, WinnerInfo,
 };
-use crate::query::{
-    GetAllBondedResponse, GetHolderResponse, LoterraBalanceResponse, TerrandResponse,
-};
+use crate::query::{GetHolderResponse, LoterraBalanceResponse, TerrandResponse};
 use crate::state::{
     combination_storage, combination_storage_read, config, config_read, poll_storage,
     poll_storage_read, poll_vote_storage, winner_storage, winner_storage_read, Combination,

--- a/src/query.rs
+++ b/src/query.rs
@@ -21,8 +21,3 @@ pub struct GetHolderResponse {
     pub available: Uint128,
     pub period: u64,
 }
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct GetAllBondedResponse {
-    pub total_bonded: Uint128,
-}


### PR DESCRIPTION
I changed the design of reject proposal now is based on Cosmos design https://docs.cosmos.network/v0.39/modules/gov/01_concepts.html#threshold

I removed the query to get all bonding LOTA tokens from staking contract, now total weight is the sum of yes and no vote, a proposal will be approved if yes weight vote are > 50% and no weight vote < 33%