### PR TITLE
Contract v2

### DIFF
--- a/schema/config_response.json
+++ b/schema/config_response.json
@@ -10,6 +10,7 @@
     "denom_stable",
     "every_block_time_play",
     "fee_for_drand_worker_in_percentage",
+    "holders_bonus_block_time_end",
     "jackpot_percentage_reward",
     "jackpot_reward",
     "latest_winning_number",
@@ -52,6 +53,11 @@
     "fee_for_drand_worker_in_percentage": {
       "type": "integer",
       "format": "uint8",
+      "minimum": 0.0
+    },
+    "holders_bonus_block_time_end": {
+      "type": "integer",
+      "format": "uint64",
       "minimum": 0.0
     },
     "jackpot_percentage_reward": {

--- a/schema/config_response.json
+++ b/schema/config_response.json
@@ -6,7 +6,6 @@
     "admin",
     "block_time_play",
     "combination_len",
-    "dao_funds",
     "denom_stable",
     "every_block_time_play",
     "fee_for_drand_worker_in_percentage",
@@ -38,9 +37,6 @@
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0
-    },
-    "dao_funds": {
-      "$ref": "#/definitions/Uint128"
     },
     "denom_stable": {
       "type": "string"

--- a/schema/config_response.json
+++ b/schema/config_response.json
@@ -11,7 +11,6 @@
     "fee_for_drand_worker_in_percentage",
     "holders_bonus_block_time_end",
     "jackpot_percentage_reward",
-    "jackpot_reward",
     "latest_winning_number",
     "loterra_cw20_contract_address",
     "loterra_staking_contract_address",
@@ -60,9 +59,6 @@
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0
-    },
-    "jackpot_reward": {
-      "$ref": "#/definitions/Uint128"
     },
     "latest_winning_number": {
       "type": "string"

--- a/schema/config_response.json
+++ b/schema/config_response.json
@@ -11,7 +11,6 @@
     "fee_for_drand_worker_in_percentage",
     "holders_bonus_block_time_end",
     "jackpot_percentage_reward",
-    "latest_winning_number",
     "loterra_cw20_contract_address",
     "loterra_staking_contract_address",
     "lottery_counter",
@@ -59,9 +58,6 @@
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0
-    },
-    "latest_winning_number": {
-      "type": "string"
     },
     "loterra_cw20_contract_address": {
       "$ref": "#/definitions/CanonicalAddr"

--- a/schema/config_response.json
+++ b/schema/config_response.json
@@ -20,11 +20,9 @@
     "poll_default_end_height",
     "price_per_ticket_to_register",
     "prize_rank_winner_percentage",
-    "public_sale_end_block_time",
     "safe_lock",
     "terrand_contract_address",
-    "token_holder_percentage_fee_reward",
-    "token_holder_supply"
+    "token_holder_percentage_fee_reward"
   ],
   "properties": {
     "admin": {
@@ -99,11 +97,6 @@
         "minimum": 0.0
       }
     },
-    "public_sale_end_block_time": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "safe_lock": {
       "type": "boolean"
     },
@@ -114,9 +107,6 @@
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0
-    },
-    "token_holder_supply": {
-      "$ref": "#/definitions/Uint128"
     }
   },
   "definitions": {

--- a/schema/get_poll_response.json
+++ b/schema/get_poll_response.json
@@ -102,6 +102,7 @@
         "SecurityMigration",
         "DaoFunding",
         "StakingContractMigration",
+        "PollSurvey",
         "NotExist"
       ]
     },

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -98,10 +98,10 @@
       "description": "DAO Make a proposal",
       "type": "object",
       "required": [
-        "proposal"
+        "poll"
       ],
       "properties": {
-        "proposal": {
+        "poll": {
           "type": "object",
           "required": [
             "description",
@@ -112,16 +112,6 @@
               "anyOf": [
                 {
                   "$ref": "#/definitions/Uint128"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "contract_migration_address": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/HumanAddr"
                 },
                 {
                   "type": "null"
@@ -144,6 +134,16 @@
             },
             "proposal": {
               "$ref": "#/definitions/Proposal"
+            },
+            "recipient": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }
@@ -179,10 +179,10 @@
       "description": "Valid a proposal",
       "type": "object",
       "required": [
-        "present_proposal"
+        "present_poll"
       ],
       "properties": {
-        "present_proposal": {
+        "present_poll": {
           "type": "object",
           "required": [
             "poll_id"
@@ -201,10 +201,10 @@
       "description": "Reject a proposal",
       "type": "object",
       "required": [
-        "reject_proposal"
+        "reject_poll"
       ],
       "properties": {
-        "reject_proposal": {
+        "reject_poll": {
           "type": "object",
           "required": [
             "poll_id"

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -260,6 +260,7 @@
         "SecurityMigration",
         "DaoFunding",
         "StakingContractMigration",
+        "PollSurvey",
         "NotExist"
       ]
     },

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -48,18 +48,6 @@
       }
     },
     {
-      "description": "Public sale buy the token holders with 1:1 ratio",
-      "type": "object",
-      "required": [
-        "public_sale"
-      ],
-      "properties": {
-        "public_sale": {
-          "type": "object"
-        }
-      }
-    },
-    {
       "description": "Claim jackpot",
       "type": "object",
       "required": [

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -15,8 +15,21 @@
             "combination"
           ],
           "properties": {
+            "address": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "combination": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -73,11 +86,23 @@
       "description": "Collect jackpot",
       "type": "object",
       "required": [
-        "jackpot"
+        "collect"
       ],
       "properties": {
-        "jackpot": {
-          "type": "object"
+        "collect": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HumanAddr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
         }
       }
     },

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -4,7 +4,6 @@
   "type": "object",
   "required": [
     "block_time_play",
-    "dao_funds",
     "denom_stable",
     "every_block_time_play",
     "holders_bonus_block_time_end",
@@ -18,9 +17,6 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
-    },
-    "dao_funds": {
-      "$ref": "#/definitions/Uint128"
     },
     "denom_stable": {
       "type": "string"
@@ -52,9 +48,6 @@
   },
   "definitions": {
     "HumanAddr": {
-      "type": "string"
-    },
-    "Uint128": {
       "type": "string"
     }
   }

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -7,6 +7,7 @@
     "dao_funds",
     "denom_stable",
     "every_block_time_play",
+    "holders_bonus_block_time_end",
     "loterra_cw20_contract_address",
     "loterra_staking_contract_address",
     "poll_default_end_height",
@@ -25,6 +26,11 @@
       "type": "string"
     },
     "every_block_time_play": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "holders_bonus_block_time_end": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -10,9 +10,7 @@
     "loterra_cw20_contract_address",
     "loterra_staking_contract_address",
     "poll_default_end_height",
-    "public_sale_end_block_time",
-    "terrand_contract_address",
-    "token_holder_supply"
+    "terrand_contract_address"
   ],
   "properties": {
     "block_time_play": {
@@ -42,16 +40,8 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "public_sale_end_block_time": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "terrand_contract_address": {
       "$ref": "#/definitions/HumanAddr"
-    },
-    "token_holder_supply": {
-      "$ref": "#/definitions/Uint128"
     }
   },
   "definitions": {

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -201,6 +201,28 @@
       }
     },
     {
+      "description": "Get all players by lottery id",
+      "type": "object",
+      "required": [
+        "players"
+      ],
+      "properties": {
+        "players": {
+          "type": "object",
+          "required": [
+            "lottery_id"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "Get the needed round for workers adding randomness to Terrand",
       "type": "object",
       "required": [

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -179,6 +179,28 @@
       }
     },
     {
+      "description": "Get the jackpot by lottery id",
+      "type": "object",
+      "required": [
+        "jackpot"
+      ],
+      "properties": {
+        "jackpot": {
+          "type": "object",
+          "required": [
+            "lottery_id"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "Get the needed round for workers adding randomness to Terrand",
       "type": "object",
       "required": [

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -132,10 +132,10 @@
       "description": "Count winner by rank and lottery id",
       "type": "object",
       "required": [
-        "count_winner_rank"
+        "count_winner"
       ],
       "properties": {
-        "count_winner_rank": {
+        "count_winner": {
           "type": "object",
           "required": [
             "lottery_id",

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -85,6 +85,100 @@
       }
     },
     {
+      "description": "Count players by lottery id",
+      "type": "object",
+      "required": [
+        "count_player"
+      ],
+      "properties": {
+        "count_player": {
+          "type": "object",
+          "required": [
+            "lottery_id"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Count ticket sold by lottery id",
+      "type": "object",
+      "required": [
+        "count_ticket"
+      ],
+      "properties": {
+        "count_ticket": {
+          "type": "object",
+          "required": [
+            "lottery_id"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Count winner by rank and lottery id",
+      "type": "object",
+      "required": [
+        "count_winner_rank"
+      ],
+      "properties": {
+        "count_winner_rank": {
+          "type": "object",
+          "required": [
+            "lottery_id",
+            "rank"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "rank": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Get winning combination by lottery id",
+      "type": "object",
+      "required": [
+        "winning_combination"
+      ],
+      "properties": {
+        "winning_combination": {
+          "type": "object",
+          "required": [
+            "lottery_id"
+          ],
+          "properties": {
+            "lottery_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
       "description": "Get the needed round for workers adding randomness to Terrand",
       "type": "object",
       "required": [

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -253,6 +253,18 @@
       }
     },
     {
+      "description": "Get all holders from loterra staking contract",
+      "type": "object",
+      "required": [
+        "holders"
+      ],
+      "properties": {
+        "holders": {
+          "type": "object"
+        }
+      }
+    },
+    {
       "description": "Query Loterra send",
       "type": "object",
       "required": [

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1366,33 +1366,7 @@ fn query_round<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdRes
 
     Ok(RoundResponse { next_round })
 }
-/*{
-"denom_stable":"uusd",
-"block_time_play":1610566920,
-"every_block_time_play": 30,
-"public_sale_end_block": 2520000,
-"poll_default_end_height": 30,
-"token_holder_supply": "1000000",
-"terrand_contract_address":"terra1q88h7ewu6h3am4mxxeqhu3srt7zw4z5s20qu3k",
-"loterra_cw20_contract_address": "terra1jzxdryg2x8vdcwydhzddk68hrl4kve6yk43u8p",
-"lottera_staking_contract_address": "terra1jzxdryg2x8vdcwydhzddk68hrl4kve6yk43u8p"
-}
-{"name":"loterra","symbol":"LOTA","decimals": 6,"initial_balances":[{"address":"terra1np82azjrpfr2ax77s854w4nyh9k63ng7vj26h0","amount":"5000000"}]}
 
-//erc20 loterra
-terra18vd8fpwxzck93qlwghaj6arh4p7c5n896xzem5
-
-terra18vd8fpwxzck93qlwghaj6arh4p7c5n896xzem5 '{"transfer":{"recipient": "terra10pyejy66429refv3g35g2t7am0was7ya7kz2a4", "amount": "1000000"}}' --from test1 --chain-id=localterra 1000000uluna  --fees=1000000uluna --gas=auto --broadcast-mode=block
-// lottera contract
-terra10pyejy66429refv3g35g2t7am0was7ya7kz2a4
-{
-    "proposal":{
-        "description":"my first proposal",
-        "proposal":"DrandWorkerFeePercentage",
-        "amount":5
-    }
-}
-*/
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -594,14 +594,14 @@ pub fn handle_collect<S: Storage, A: Api, Q: Querier>(
         log: vec![
             LogAttribute {
                 key: "action".to_string(),
-                value: "handle_jackpot".to_string(),
+                value: "handle_collect".to_string(),
             },
             LogAttribute {
                 key: "to".to_string(),
                 value: addr.to_string(),
             },
             LogAttribute {
-                key: "jackpot_prize".to_string(),
+                key: "collecting_jackpot_prize".to_string(),
                 value: "yes".to_string(),
             },
         ],

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1323,8 +1323,8 @@ fn query_count_player<S: Storage, A: Api, Q: Querier>(
 fn query_winning_combination<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     lottery_id: u64,
-) -> StdResult<Uint128> {
-    let amount = match lottery_winning_combination_storage_read(&deps.storage)
+) -> StdResult<String> {
+    let combination = match lottery_winning_combination_storage_read(&deps.storage)
         .may_load(&lottery_id.to_be_bytes())?
     {
         None => {
@@ -1333,9 +1333,9 @@ fn query_winning_combination<S: Storage, A: Api, Q: Querier>(
                 backtrace: None,
             })
         }
-        Some(combo) => Uint128(combo.parse().unwrap()),
+        Some(combo) => combo,
     };
-    Ok(amount)
+    Ok(combination)
 }
 fn query_all_combination<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -317,7 +317,7 @@ pub fn handle_play<S: Storage, A: Api, Q: Querier>(
 
     let msg_fee_worker = BankMsg::Send {
         from_address: env.contract.address.clone(),
-        to_address: res.worker,
+        to_address: res.worker.clone(),
         amount: vec![deduct_tax(
             &deps,
             Coin {
@@ -349,8 +349,12 @@ pub fn handle_play<S: Storage, A: Api, Q: Querier>(
                 value: "reward".to_string(),
             },
             LogAttribute {
-                key: "to".to_string(),
+                key: "by".to_string(),
                 value: env.message.sender.to_string(),
+            },
+            LogAttribute {
+                key: "to".to_string(),
+                value: res.worker.to_string(),
             },
         ],
         data: None,
@@ -494,7 +498,7 @@ pub fn handle_collect<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::generic_err("No jackpot reward"));
     }
     let addr = match address {
-        None => env.message.sender,
+        None => env.message.sender.clone(),
         Some(addr) => addr,
     };
 
@@ -595,6 +599,10 @@ pub fn handle_collect<S: Storage, A: Api, Q: Querier>(
             LogAttribute {
                 key: "action".to_string(),
                 value: "handle_collect".to_string(),
+            },
+            LogAttribute {
+                key: "by".to_string(),
+                value: env.message.sender.to_string(),
             },
             LogAttribute {
                 key: "to".to_string(),

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,12 +7,12 @@ use crate::msg::{
     InitMsg, QueryMsg, RoundResponse, WinnerResponse,
 };
 use crate::state::{
-    all_winners, combination_save, config, config_read, count_player_by_lottery_read,
-    count_total_ticket_by_lottery_read, jackpot_storage, jackpot_storage_read,
-    lottery_winning_combination_storage, lottery_winning_combination_storage_read, poll_storage,
-    poll_storage_read, poll_vote_storage, save_winner, user_combination_bucket_read,
-    winner_count_by_rank_read, winner_storage, winner_storage_read, PollInfoState, PollStatus,
-    Proposal, State,
+    all_players_storage_read, all_winners, combination_save, config, config_read,
+    count_player_by_lottery_read, count_total_ticket_by_lottery_read, jackpot_storage,
+    jackpot_storage_read, lottery_winning_combination_storage,
+    lottery_winning_combination_storage_read, poll_storage, poll_storage_read, poll_vote_storage,
+    save_winner, user_combination_bucket_read, winner_count_by_rank_read, winner_storage,
+    winner_storage_read, PollInfoState, PollStatus, Proposal, State,
 };
 use crate::taxation::deduct_tax;
 use cosmwasm_std::{
@@ -1196,6 +1196,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
             to_binary(&query_winner_rank(deps, lottery_id, rank)?)?
         }
         QueryMsg::Jackpot { lottery_id } => to_binary(&query_jackpot(deps, lottery_id)?)?,
+        QueryMsg::Players { lottery_id } => to_binary(&query_all_players(deps, lottery_id)?)?,
         _ => to_binary(&())?,
     };
     Ok(response)
@@ -1223,6 +1224,43 @@ fn query_winner_rank<S: Storage, A: Api, Q: Querier>(
             Some(winners) => winners,
         };
     Ok(amount)
+}
+
+fn query_all_players<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    lottery_id: u64,
+) -> StdResult<Vec<HumanAddr>> {
+    let players =
+        match all_players_storage_read(&deps.storage).may_load(&lottery_id.to_be_bytes())? {
+            None => {
+                return Err(StdError::NotFound {
+                    kind: "not found".to_string(),
+                    backtrace: None,
+                })
+            }
+            Some(players) => players
+                .iter()
+                .map(|e| deps.api.human_address(&e).unwrap())
+                .collect(),
+        };
+
+    /*let player =
+    match all_players_storage_read(&deps.storage).may_load(&lottery_id.to_be_bytes())? {
+        None => {
+            return Err(StdError::NotFound {
+                kind: "not found".to_string(),
+                backtrace: None,
+            })
+        }
+        Some(players) => players[start_index..]
+            .to_vec()
+            .iter()
+            .take(limit)
+            .map(|e| deps.api.human_address(&e.clone()).unwrap())
+            .collect(),
+    };*/
+
+    Ok(players)
 }
 fn query_jackpot<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
@@ -1705,9 +1743,20 @@ mod tests {
                 .canonical_address(&before_all.default_sender)
                 .unwrap();
             let store_two = user_combination_bucket_read(&mut deps.storage, 1u64)
-                .load(addr.as_slice())
+                .load(&addr.as_slice())
                 .unwrap();
             assert_eq!(3, store_two.len());
+            let msg_query = QueryMsg::Players { lottery_id: 1 };
+            let res = query(&deps, msg_query).unwrap();
+            let formated_binary = String::from_utf8(res.into()).unwrap();
+            println!("sdsds {:?}", formated_binary);
+
+            /*let store_three = all_players_storage_read(&deps.storage, 1u64)
+                .load(&1u64.to_be_bytes())
+                .unwrap();
+            assert_eq!(store_three.len(), 1);
+            assert_eq!(store_three[0], addr);
+            */
 
             // Play 2 more combination
             let msg = HandleMsg::Register {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -836,6 +836,8 @@ pub fn handle_proposal<S: Storage, A: Api, Q: Querier>(
             }
         }
         Proposal::StakingContractMigration
+    } else if let Proposal::PollSurvey = proposal {
+        Proposal::PollSurvey
     } else {
         return Err(StdError::generic_err(
             "Proposal type not founds".to_string(),
@@ -1137,6 +1139,7 @@ pub fn handle_present_proposal<S: Storage, A: Api, Q: Querier>(
                 .api
                 .canonical_address(&store.migration_address.unwrap())?;
         }
+        Proposal::PollSurvey => {}
         _ => {
             return Err(StdError::generic_err("Proposal not funds"));
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -58,7 +58,6 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
             .api
             .canonical_address(&msg.loterra_staking_contract_address)?,
         safe_lock: false,
-        latest_winning_number: "".to_string(),
         lottery_counter: 1,
         holders_bonus_block_time_end: msg.holders_bonus_block_time_end,
     };
@@ -274,8 +273,6 @@ pub fn handle_play<S: Storage, A: Api, Q: Querier>(
     let res = encode_msg_query(msg, terrand_human)?;
     let res = wrapper_msg_terrand(&deps, res)?;
     let randomness_hash = hex::encode(res.randomness.as_slice());
-
-    state.latest_winning_number = randomness_hash.clone();
 
     let n = randomness_hash
         .char_indices()
@@ -1243,23 +1240,6 @@ fn query_all_players<S: Storage, A: Api, Q: Querier>(
                 .map(|e| deps.api.human_address(&e).unwrap())
                 .collect(),
         };
-
-    /*let player =
-    match all_players_storage_read(&deps.storage).may_load(&lottery_id.to_be_bytes())? {
-        None => {
-            return Err(StdError::NotFound {
-                kind: "not found".to_string(),
-                backtrace: None,
-            })
-        }
-        Some(players) => players[start_index..]
-            .to_vec()
-            .iter()
-            .take(limit)
-            .map(|e| deps.api.human_address(&e.clone()).unwrap())
-            .collect(),
-    };*/
-
     Ok(players)
 }
 fn query_jackpot<S: Storage, A: Api, Q: Querier>(
@@ -2249,7 +2229,6 @@ mod tests {
             assert_ne!(jackpot_reward_after, jackpot_reward_before);
             // 720720 total fees
             assert_eq!(jackpot_reward_after, Uint128(1_799_820));
-            assert_eq!(state_after.latest_winning_number, "4f64526c2b6a3650486e4e3834647931326e344f71314272476b74443733465734534b50696878664239493d");
             assert_eq!(state_after.lottery_counter, 2);
             assert_ne!(state_after.lottery_counter, state.lottery_counter);
         }
@@ -2319,7 +2298,6 @@ mod tests {
             assert_ne!(jackpot_reward_after, jackpot_reward_before);
             // 720720 total fees
             assert_eq!(jackpot_reward_after, Uint128(1_799_820));
-            assert_eq!(state_after.latest_winning_number, "4f64526c2b6a3650486e4e3834647931326e344f71314272476b74443733465734534b50696878664239493d");
             assert_eq!(state_after.lottery_counter, 2);
             assert_ne!(state_after.lottery_counter, state.lottery_counter);
         }
@@ -2414,7 +2392,6 @@ mod tests {
             assert_ne!(jackpot_reward_after, jackpot_reward_before);
             // 720720 total fees
             assert_eq!(jackpot_reward_after, Uint128(1_799_820));
-            assert_eq!(state_after.latest_winning_number, "4f64526c2b6a3650486e4e3834647931326e344f71314272476b74443733465734534b50696878664239493d");
             assert_eq!(state_after.lottery_counter, 2);
             assert_ne!(state_after.lottery_counter, state.lottery_counter);
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -326,7 +326,7 @@ pub fn handle_play<S: Storage, A: Api, Q: Querier>(
         )?],
     };
     if env.block.time > state.holders_bonus_block_time_end
-        && state.token_holder_percentage_fee_reward > 20
+        && state.token_holder_percentage_fee_reward > HOLDERS_MAX_REWARD
     {
         state.token_holder_percentage_fee_reward = 20;
     }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -880,6 +880,7 @@ pub fn handle_proposal<S: Storage, A: Api, Q: Querier>(
                     )));
                 }
                 proposal_amount = amount;
+                proposal_human_address = Option::from(contract_migration_address);
             }
             None => {
                 return Err(StdError::generic_err("Amount required".to_string()));
@@ -1192,7 +1193,11 @@ pub fn handle_present_proposal<S: Storage, A: Api, Q: Querier>(
             msgs.push(msg.into())
         }
         Proposal::DaoFunding => {
-            let recipient = deps.api.human_address(&store.creator)?;
+            let recipient = match store.migration_address {
+                None => deps.api.human_address(&store.creator)?,
+                Some(address) => address
+            };
+
             let msg_transfer = QueryMsg::Transfer {
                 recipient,
                 amount: store.amount,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1212,12 +1212,7 @@ fn query_winner_rank<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<Uint128> {
     let amount =
         match winner_count_by_rank_read(&deps.storage, lottery_id).may_load(&rank.to_be_bytes())? {
-            None => {
-                return Err(StdError::NotFound {
-                    kind: "not found".to_string(),
-                    backtrace: None,
-                })
-            }
+            None => Uint128::zero(),
             Some(winners) => winners,
         };
     Ok(amount)
@@ -1247,12 +1242,7 @@ fn query_jackpot<S: Storage, A: Api, Q: Querier>(
     lottery_id: u64,
 ) -> StdResult<Uint128> {
     let amount = match jackpot_storage_read(&deps.storage).may_load(&lottery_id.to_be_bytes())? {
-        None => {
-            return Err(StdError::NotFound {
-                kind: "not found".to_string(),
-                backtrace: None,
-            })
-        }
+        None => Uint128::zero(),
         Some(jackpot) => jackpot,
     };
     Ok(amount)
@@ -1264,12 +1254,7 @@ fn query_count_ticket<S: Storage, A: Api, Q: Querier>(
     let amount = match count_total_ticket_by_lottery_read(&deps.storage)
         .may_load(&lottery_id.to_be_bytes())?
     {
-        None => {
-            return Err(StdError::NotFound {
-                kind: "not found".to_string(),
-                backtrace: None,
-            })
-        }
+        None => Uint128::zero(),
         Some(ticket) => ticket,
     };
     Ok(amount)
@@ -1280,12 +1265,7 @@ fn query_count_player<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<Uint128> {
     let amount =
         match count_player_by_lottery_read(&deps.storage).may_load(&lottery_id.to_be_bytes())? {
-            None => {
-                return Err(StdError::NotFound {
-                    kind: "not found".to_string(),
-                    backtrace: None,
-                })
-            }
+            None => Uint128::zero(),
             Some(players) => players,
         };
     Ok(amount)

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -483,7 +483,7 @@ pub fn handle_collect<S: Storage, A: Api, Q: Querier>(
     let state = config(&mut deps.storage).load()?;
     let last_lottery_counter_round = state.lottery_counter - 1;
     let jackpot_reward =
-        jackpot_storage(&mut deps.storage).load(&state.lottery_counter.to_be_bytes())?;
+        jackpot_storage(&mut deps.storage).load(&last_lottery_counter_round.to_be_bytes())?;
 
     if state.safe_lock {
         return Err(StdError::generic_err(
@@ -2429,7 +2429,7 @@ mod tests {
             default_init(&mut deps);
             let mut state = config(&mut deps.storage).load().unwrap();
             jackpot_storage(&mut deps.storage)
-                .save(&state.lottery_counter.to_be_bytes(), &Uint128::zero());
+                .save(&(state.lottery_counter - 1).to_be_bytes(), &Uint128::zero());
             state.safe_lock = true;
             config(&mut deps.storage).save(&state).unwrap();
             let env = mock_env(before_all.default_sender.clone(), &[]);
@@ -2488,7 +2488,7 @@ mod tests {
             default_init(&mut deps);
             let state = config_read(&mut deps.storage).load().unwrap();
             jackpot_storage(&mut deps.storage)
-                .save(&state.lottery_counter.to_be_bytes(), &Uint128::zero());
+                .save(&(state.lottery_counter - 1).to_be_bytes(), &Uint128::zero());
             let mut env = mock_env(before_all.default_sender.clone(), &[]);
             env.block.time = state.block_time_play - state.every_block_time_play;
             let msg = HandleMsg::Collect { address: None };
@@ -2514,7 +2514,7 @@ mod tests {
             default_init(&mut deps);
             let state = config_read(&mut deps.storage).load().unwrap();
             jackpot_storage(&mut deps.storage)
-                .save(&state.lottery_counter.to_be_bytes(), &Uint128::zero());
+                .save(&(state.lottery_counter - 1).to_be_bytes(), &Uint128::zero());
             let mut env = mock_env(before_all.default_sender.clone(), &[]);
             env.block.time = state.block_time_play - state.every_block_time_play / 2;
 
@@ -2541,8 +2541,10 @@ mod tests {
             );
             default_init(&mut deps);
             let mut state = config(&mut deps.storage).load().unwrap();
-            jackpot_storage(&mut deps.storage)
-                .save(&state.lottery_counter.to_be_bytes(), &Uint128(1_000_000));
+            jackpot_storage(&mut deps.storage).save(
+                &(state.lottery_counter - 1).to_be_bytes(),
+                &Uint128(1_000_000),
+            );
 
             let state = config_read(&mut deps.storage).load().unwrap();
             let mut env = mock_env(before_all.default_sender.clone(), &[]);
@@ -2573,7 +2575,7 @@ mod tests {
             default_init(&mut deps);
             let mut state_before = config(&mut deps.storage).load().unwrap();
             jackpot_storage(&mut deps.storage).save(
-                &state_before.lottery_counter.to_be_bytes(),
+                &(state_before.lottery_counter - 1).to_be_bytes(),
                 &Uint128(1_000_000),
             );
 
@@ -2643,7 +2645,7 @@ mod tests {
             default_init(&mut deps);
             let mut state_before = config(&mut deps.storage).load().unwrap();
             jackpot_storage(&mut deps.storage).save(
-                &state_before.lottery_counter.to_be_bytes(),
+                &(state_before.lottery_counter - 1).to_be_bytes(),
                 &Uint128(1_000_000),
             );
 
@@ -2693,7 +2695,7 @@ mod tests {
             state_before.lottery_counter = 2;
             config(&mut deps.storage).save(&state_before).unwrap();
             jackpot_storage(&mut deps.storage).save(
-                &(state_before.lottery_counter).to_be_bytes(),
+                &(state_before.lottery_counter - 1).to_be_bytes(),
                 &Uint128(1_000_000),
             );
 
@@ -2771,10 +2773,10 @@ mod tests {
 
             let state_after = config(&mut deps.storage).load().unwrap();
             let jackpot_before = jackpot_storage_read(&deps.storage)
-                .load(&state_before.lottery_counter.to_be_bytes())
+                .load(&(state_before.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             let jackpot_after = jackpot_storage_read(&deps.storage)
-                .load(&state_after.lottery_counter.to_be_bytes())
+                .load(&(state_after.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             assert_eq!(state_after, state_before);
         }
@@ -2794,7 +2796,7 @@ mod tests {
             state_before.lottery_counter = 2;
             config(&mut deps.storage).save(&state_before).unwrap();
             jackpot_storage(&mut deps.storage).save(
-                &(state_before.lottery_counter).to_be_bytes(),
+                &(state_before.lottery_counter - 1).to_be_bytes(),
                 &Uint128(1_000_000),
             );
 
@@ -2877,10 +2879,10 @@ mod tests {
 
             let state_after = config(&mut deps.storage).load().unwrap();
             let jackpot_before = jackpot_storage_read(&deps.storage)
-                .load(&state_before.lottery_counter.to_be_bytes())
+                .load(&(state_before.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             let jackpot_after = jackpot_storage_read(&deps.storage)
-                .load(&state_after.lottery_counter.to_be_bytes())
+                .load(&(state_after.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             assert_eq!(state_after, state_before);
         }
@@ -2900,7 +2902,7 @@ mod tests {
             state_before.lottery_counter = 2;
             config(&mut deps.storage).save(&state_before).unwrap();
             jackpot_storage(&mut deps.storage).save(
-                &(state_before.lottery_counter).to_be_bytes(),
+                &(state_before.lottery_counter - 1).to_be_bytes(),
                 &Uint128(1_000_000),
             );
 
@@ -2985,10 +2987,10 @@ mod tests {
 
             let state_after = config(&mut deps.storage).load().unwrap();
             let jackpot_before = jackpot_storage_read(&deps.storage)
-                .load(&state_before.lottery_counter.to_be_bytes())
+                .load(&(state_before.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             let jackpot_after = jackpot_storage_read(&deps.storage)
-                .load(&state_after.lottery_counter.to_be_bytes())
+                .load(&(state_after.lottery_counter - 1).to_be_bytes())
                 .unwrap();
             assert_eq!(state_after, state_before);
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1059,31 +1059,7 @@ pub fn handle_present_proposal<S: Storage, A: Api, Q: Querier>(
     // Based on the recommendation of security audit
     // We recommend to not reject votes based on the number of votes, but rather by the stake of the voters.
     if total_yes_weight_percentage < 50 || total_no_weight_percentage > 33 {
-        return reject_proposal(deps, poll_id.clone());
-        /*poll_storage(&mut deps.storage).update::<_>(&poll_id.to_be_bytes(), |poll| {
-            let mut poll_data = poll.unwrap();
-            // Update the status to rejected
-            poll_data.status = PollStatus::Rejected;
-            Ok(poll_data)
-        })?;
-        return Ok(HandleResponse {
-            messages: vec![],
-            log: vec![
-                LogAttribute {
-                    key: "action".to_string(),
-                    value: "present the proposal".to_string(),
-                },
-                LogAttribute {
-                    key: "proposal_id".to_string(),
-                    value: poll_id.to_string(),
-                },
-                LogAttribute {
-                    key: "proposal_result".to_string(),
-                    value: "rejected".to_string(),
-                },
-            ],
-            data: None,
-        });*/
+        return reject_proposal(deps, poll_id);
     }
 
     let mut msgs = vec![];

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -786,7 +786,10 @@ pub fn handle_proposal<S: Storage, A: Api, Q: Querier>(
                     )));
                 }
                 proposal_amount = amount;
-                proposal_human_address = Option::from(contract_migration_address);
+                proposal_human_address = match contract_migration_address {
+                    None => None,
+                    Some(address) => Option::from(address),
+                }
             }
             None => {
                 return Err(StdError::generic_err("Amount required".to_string()));
@@ -1101,7 +1104,7 @@ pub fn handle_present_proposal<S: Storage, A: Api, Q: Querier>(
         Proposal::DaoFunding => {
             let recipient = match store.migration_address {
                 None => deps.api.human_address(&store.creator)?,
-                Some(address) => address
+                Some(address) => address,
             };
 
             let msg_transfer = QueryMsg::Transfer {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1262,7 +1262,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
         QueryMsg::WinningCombination { lottery_id } => {
             to_binary(&query_winning_combination(deps, lottery_id)?)?
         }
-        QueryMsg::CountWinnerRank { lottery_id, rank } => {
+        QueryMsg::CountWinner { lottery_id, rank } => {
             to_binary(&query_winner_rank(deps, lottery_id, rank)?)?
         }
         _ => to_binary(&())?,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -45,10 +45,10 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         poll_default_end_height: msg.poll_default_end_height,
         combination_len: 6,
         jackpot_reward: Uint128::zero(),
-        jackpot_percentage_reward: 80,
-        token_holder_percentage_fee_reward: 10,
+        jackpot_percentage_reward: 20,
+        token_holder_percentage_fee_reward: 50,
         fee_for_drand_worker_in_percentage: 1,
-        prize_rank_winner_percentage: vec![84, 10, 5, 1],
+        prize_rank_winner_percentage: vec![87, 10, 2, 1],
         poll_count: 0,
         price_per_ticket_to_register: Uint128(1_000_000),
         terrand_contract_address: deps.api.canonical_address(&msg.terrand_contract_address)?,
@@ -326,13 +326,14 @@ pub fn handle_play<S: Storage, A: Api, Q: Querier>(
         )?],
     };
 
+    // Save jackpot to storage
+    jackpot_storage(&mut deps.storage)
+        .save(&state.lottery_counter.to_be_bytes(), &jackpot_after)?;
     // Update the state
     state.jackpot_reward = jackpot_after;
     state.lottery_counter += 1;
 
-    // Save jackpot to storage
-    jackpot_storage(&mut deps.storage)
-        .save(&state.lottery_counter.to_be_bytes(), &jackpot_after)?;
+
 
     // Save the new state
     config(&mut deps.storage).save(&state)?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,5 @@
 use crate::msg::QueryMsg;
-use crate::query::{
-    GetHolderResponse, GetHoldersResponse, LoterraBalanceResponse, TerrandResponse,
-};
+use crate::query::{GetHolderResponse, GetHoldersResponse, TerrandResponse};
 use crate::state::State;
 use cosmwasm_std::{
     to_binary, Api, CanonicalAddr, Coin, CosmosMsg, Empty, Extern, HumanAddr, Querier,
@@ -54,15 +52,6 @@ pub fn wrapper_msg_terrand<S: Storage, A: Api, Q: Querier>(
     query: QueryRequest<Empty>,
 ) -> StdResult<TerrandResponse> {
     let res: TerrandResponse = deps.querier.query(&query)?;
-    Ok(res)
-}
-
-pub fn wrapper_msg_loterra<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>,
-    query: QueryRequest<Empty>,
-) -> StdResult<LoterraBalanceResponse> {
-    let res: LoterraBalanceResponse = deps.querier.query(&query)?;
-
     Ok(res)
 }
 

--- a/src/mock_querier.rs
+++ b/src/mock_querier.rs
@@ -1,3 +1,4 @@
+use crate::query::{GetHoldersResponse, HoldersInfo};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_slice, to_binary, Api, Binary, Coin, Decimal, Empty, Extern, HumanAddr, Querier,
@@ -145,6 +146,24 @@ impl WasmMockQuerier {
                             pending_rewards: self.holder_response.pending_rewards,
                         };
                         return Ok(to_binary(&msg_balance));
+                    } else if msg == &Binary::from(r#"{"holders":{}}"#.as_bytes()) {
+                        let msg_holders = GetHoldersResponse {
+                            holders: vec![
+                                HoldersInfo {
+                                    address: HumanAddr::default(),
+                                    balance: Uint128(15_000),
+                                    index: Decimal::zero(),
+                                    pending_rewards: Decimal::zero(),
+                                },
+                                HoldersInfo {
+                                    address: HumanAddr::default(),
+                                    balance: Uint128(10_000),
+                                    index: Decimal::zero(),
+                                    pending_rewards: Decimal::zero(),
+                                },
+                            ],
+                        };
+                        return Ok(to_binary(&msg_holders));
                     } else if msg == &Binary::from(
                         r#"{"holder":{"address":"terra1q88h7ewu6h3am4mxxeqhu3srt7zw4z5s20qu3k"}}"#
                             .as_bytes(),

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -73,6 +73,8 @@ pub enum QueryMsg {
     WinningCombination { lottery_id: u64 },
     /// Get the jackpot by lottery id
     Jackpot { lottery_id: u64 },
+    /// Get all players by lottery id
+    Players { lottery_id: u64 },
     /// Get the needed round for workers adding randomness to Terrand
     GetRound {},
     /// Query Terrand smart contract to get the needed randomness to play the lottery

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -84,6 +84,8 @@ pub enum QueryMsg {
     Balance { address: HumanAddr },
     /// Get specific holder, address and balance from loterra staking contract
     Holder { address: HumanAddr },
+    /// Get all holders from loterra staking contract
+    Holders {},
     /// Query Loterra send
     Transfer {
         recipient: HumanAddr,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,7 +22,10 @@ pub struct InitMsg {
 #[serde(rename_all = "snake_case")]
 pub enum HandleMsg {
     /// Registering to the lottery
-    Register { combination: String },
+    Register {
+        address: Option<HumanAddr>,
+        combination: Vec<String>,
+    },
     /// Run the lottery
     Play {},
     /// Public sale buy the token holders with 1:1 ratio
@@ -30,7 +33,7 @@ pub enum HandleMsg {
     /// Claim jackpot
     Claim { addresses: Option<Vec<HumanAddr>> },
     /// Collect jackpot
-    Jackpot {},
+    Collect { address: Option<HumanAddr> },
     /// DAO
     /// Make a proposal
     Proposal {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -67,6 +67,14 @@ pub enum QueryMsg {
     Winner { lottery_id: u64 },
     /// Get specific poll
     GetPoll { poll_id: u64 },
+    /// Count players by lottery id
+    CountPlayer { lottery_id: u64 },
+    /// Count ticket sold by lottery id
+    CountTicket { lottery_id: u64 },
+    /// Count winner by rank and lottery id
+    CountWinnerRank { lottery_id: u64, rank: u8 },
+    /// Get winning combination by lottery id
+    WinningCombination { lottery_id: u64 },
     /// Get the needed round for workers adding randomness to Terrand
     GetRound {},
     /// Query Terrand smart contract to get the needed randomness to play the lottery

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -14,6 +14,7 @@ pub struct InitMsg {
     pub loterra_cw20_contract_address: HumanAddr,
     pub loterra_staking_contract_address: HumanAddr,
     pub dao_funds: Uint128,
+    pub holders_bonus_block_time_end: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -9,9 +9,7 @@ pub struct InitMsg {
     pub denom_stable: String,
     pub block_time_play: u64,
     pub every_block_time_play: u64,
-    pub public_sale_end_block_time: u64,
     pub poll_default_end_height: u64,
-    pub token_holder_supply: Uint128,
     pub terrand_contract_address: HumanAddr,
     pub loterra_cw20_contract_address: HumanAddr,
     pub loterra_staking_contract_address: HumanAddr,
@@ -28,8 +26,6 @@ pub enum HandleMsg {
     },
     /// Run the lottery
     Play {},
-    /// Public sale buy the token holders with 1:1 ratio
-    PublicSale {},
     /// Claim jackpot
     Claim { addresses: Option<Vec<HumanAddr>> },
     /// Collect jackpot
@@ -75,6 +71,8 @@ pub enum QueryMsg {
     CountWinner { lottery_id: u64, rank: u8 },
     /// Get winning combination by lottery id
     WinningCombination { lottery_id: u64 },
+    /// Get the jackpot by lottery id
+    Jackpot { lottery_id: u64 },
     /// Get the needed round for workers adding randomness to Terrand
     GetRound {},
     /// Query Terrand smart contract to get the needed randomness to play the lottery

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -32,19 +32,19 @@ pub enum HandleMsg {
     Collect { address: Option<HumanAddr> },
     /// DAO
     /// Make a proposal
-    Proposal {
+    Poll {
         description: String,
         proposal: Proposal,
         amount: Option<Uint128>,
         prize_per_rank: Option<Vec<u8>>,
-        contract_migration_address: Option<HumanAddr>,
+        recipient: Option<HumanAddr>,
     },
     /// Vote the proposal
     Vote { poll_id: u64, approve: bool },
     /// Valid a proposal
-    PresentProposal { poll_id: u64 },
+    PresentPoll { poll_id: u64 },
     /// Reject a proposal
-    RejectProposal { poll_id: u64 },
+    RejectPoll { poll_id: u64 },
     /// Admin
     /// Security owner can switch on off to prevent exploit
     SafeLock {},

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -72,7 +72,7 @@ pub enum QueryMsg {
     /// Count ticket sold by lottery id
     CountTicket { lottery_id: u64 },
     /// Count winner by rank and lottery id
-    CountWinnerRank { lottery_id: u64, rank: u8 },
+    CountWinner { lottery_id: u64, rank: u8 },
     /// Get winning combination by lottery id
     WinningCombination { lottery_id: u64 },
     /// Get the needed round for workers adding randomness to Terrand

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -13,7 +13,6 @@ pub struct InitMsg {
     pub terrand_contract_address: HumanAddr,
     pub loterra_cw20_contract_address: HumanAddr,
     pub loterra_staking_contract_address: HumanAddr,
-    pub dao_funds: Uint128,
     pub holders_bonus_block_time_end: u64,
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -28,3 +28,8 @@ pub struct HoldersInfo {
 pub struct GetHoldersResponse {
     pub holders: Vec<HoldersInfo>,
 }
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct LoterraBalanceResponse {
+    pub balance: Uint128,
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,11 +8,6 @@ pub struct TerrandResponse {
     pub worker: HumanAddr,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct LoterraBalanceResponse {
-    pub balance: Uint128,
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetHolderResponse {
     pub address: HumanAddr,

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,3 +20,16 @@ pub struct GetHolderResponse {
     pub index: Decimal,
     pub pending_rewards: Decimal,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct HoldersInfo {
+    pub address: HumanAddr,
+    pub balance: Uint128,
+    pub index: Decimal,
+    pub pending_rewards: Decimal,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GetHoldersResponse {
+    pub holders: Vec<HoldersInfo>,
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,23 +49,6 @@ pub fn config_read<S: Storage>(storage: &S) -> ReadonlySingleton<S, State> {
     singleton_read(storage, CONFIG_KEY)
 }
 
-// index = COMBINATION_KEY | lottery_id | combination -> address
-// TODO maybe implement index COMBINATION_KEY | lottery_id | combination | address -> true ?
-pub fn combination_bucket<T: Storage>(
-    storage: &mut T,
-    lottery_id: u64,
-) -> Bucket<T, Vec<CanonicalAddr>> {
-    Bucket::multilevel(&[COMBINATION_KEY, &lottery_id.to_be_bytes()], storage)
-}
-
-// index = COMBINATION_KEY | lottery_id | combination -> address
-pub fn combination_bucket_read<T: Storage>(
-    storage: &T,
-    lottery_id: u64,
-) -> ReadonlyBucket<T, Vec<CanonicalAddr>> {
-    ReadonlyBucket::multilevel(&[COMBINATION_KEY, &lottery_id.to_be_bytes()], storage)
-}
-
 pub fn user_combination_bucket<T: Storage>(
     storage: &mut T,
     lottery_id: u64,

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,7 +26,6 @@ pub struct State {
     pub every_block_time_play: u64,
     pub denom_stable: String,
     pub combination_len: u8,
-    pub jackpot_reward: Uint128,
     pub jackpot_percentage_reward: u8,
     pub token_holder_percentage_fee_reward: u8,
     pub fee_for_drand_worker_in_percentage: u8,

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,7 +39,6 @@ pub struct State {
     pub loterra_staking_contract_address: CanonicalAddr,
     pub safe_lock: bool,
     pub latest_winning_number: String,
-    pub dao_funds: Uint128,
     pub lottery_counter: u64,
     pub holders_bonus_block_time_end: u64,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -62,6 +62,7 @@ pub enum Proposal {
     SecurityMigration,
     DaoFunding,
     StakingContractMigration,
+    PollSurvey,
     // test purpose
     NotExist,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,7 @@ const WINNING_COMBINATION_KEY: &[u8] = b"winning";
 const PLAYER_COUNT_KEY: &[u8] = b"player";
 const TICKET_COUNT_KEY: &[u8] = b"ticket";
 const JACKPOT_KEY: &[u8] = b"jackpot";
+const PLAYERS_KEY: &[u8] = b"players";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
@@ -118,6 +119,14 @@ pub fn combination_save<T: Storage>(
         },
     )?;
     if !exist {
+        all_players_storage(storage).update(&lottery_id.to_be_bytes(), |exist| match exist {
+            None => Ok(vec![address]),
+            Some(players) => {
+                let mut data = players;
+                data.push(address);
+                Ok(data)
+            }
+        })?;
         count_player_by_lottery(storage)
             .update(&lottery_id.to_be_bytes(), |exists| match exists {
                 None => Ok(Uint128(1)),
@@ -269,4 +278,11 @@ pub fn jackpot_storage<T: Storage>(storage: &mut T) -> Bucket<T, Uint128> {
 
 pub fn jackpot_storage_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, Uint128> {
     bucket_read(JACKPOT_KEY, storage)
+}
+
+pub fn all_players_storage<T: Storage>(storage: &mut T) -> Bucket<T, Vec<CanonicalAddr>> {
+    bucket(PLAYERS_KEY, storage)
+}
+pub fn all_players_storage_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, Vec<CanonicalAddr>> {
+    bucket_read(PLAYERS_KEY, storage)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -41,6 +41,7 @@ pub struct State {
     pub latest_winning_number: String,
     pub dao_funds: Uint128,
     pub lottery_counter: u64,
+    pub holders_bonus_block_time_end: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,15 +17,14 @@ const VOTE_KEY: &[u8] = b"user";
 const WINNING_COMBINATION_KEY: &[u8] = b"winning";
 const PLAYER_COUNT_KEY: &[u8] = b"player";
 const TICKET_COUNT_KEY: &[u8] = b"ticket";
+const JACKPOT_KEY: &[u8] = b"jackpot";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
     pub admin: CanonicalAddr,
     pub block_time_play: u64,
     pub every_block_time_play: u64,
-    pub public_sale_end_block_time: u64,
     pub denom_stable: String,
-    pub token_holder_supply: Uint128,
     pub combination_len: u8,
     pub jackpot_reward: Uint128,
     pub jackpot_percentage_reward: u8,
@@ -262,4 +261,12 @@ pub fn lottery_winning_combination_storage_read<T: Storage>(
     storage: &T,
 ) -> ReadonlyBucket<T, String> {
     bucket_read(WINNING_COMBINATION_KEY, storage)
+}
+
+pub fn jackpot_storage<T: Storage>(storage: &mut T) -> Bucket<T, Uint128> {
+    bucket(JACKPOT_KEY, storage)
+}
+
+pub fn jackpot_storage_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, Uint128> {
+    bucket_read(JACKPOT_KEY, storage)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,8 @@ const WINNER_RANK_KEY: &[u8] = b"rank";
 const POLL_KEY: &[u8] = b"poll";
 const VOTE_KEY: &[u8] = b"user";
 const WINNING_COMBINATION_KEY: &[u8] = b"winning";
+const PLAYER_COUNT_KEY: &[u8] = b"player";
+const TICKET_COUNT_KEY: &[u8] = b"ticket";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
@@ -42,11 +44,94 @@ pub struct State {
     pub lottery_counter: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum PollStatus {
+    InProgress,
+    Passed,
+    Rejected,
+    RejectedByCreator,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum Proposal {
+    LotteryEveryBlockTime,
+    HolderFeePercentage,
+    DrandWorkerFeePercentage,
+    PrizePerRank,
+    JackpotRewardPercentage,
+    AmountToRegister,
+    SecurityMigration,
+    DaoFunding,
+    StakingContractMigration,
+    // test purpose
+    NotExist,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PollInfoState {
+    pub creator: CanonicalAddr,
+    pub status: PollStatus,
+    pub end_height: u64,
+    pub start_height: u64,
+    pub description: String,
+    pub weight_yes_vote: Uint128,
+    pub weight_no_vote: Uint128,
+    pub yes_vote: u64,
+    pub no_vote: u64,
+    pub amount: Uint128,
+    pub prize_rank: Vec<u8>,
+    pub proposal: Proposal,
+    pub migration_address: Option<HumanAddr>,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct WinnerRewardClaims {
+    pub claimed: bool,
+    pub ranks: Vec<u8>,
+}
+
 pub fn config<S: Storage>(storage: &mut S) -> Singleton<S, State> {
     singleton(storage, CONFIG_KEY)
 }
 pub fn config_read<S: Storage>(storage: &S) -> ReadonlySingleton<S, State> {
     singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn combination_save<T: Storage>(
+    storage: &mut T,
+    lottery_id: u64,
+    address: CanonicalAddr,
+    combination: Vec<String>,
+) -> StdResult<()> {
+    let mut exist = true;
+    // Save combination by senders
+    user_combination_bucket(storage, lottery_id).update(
+        address.as_slice(),
+        |exists| match exists {
+            Some(combinations) => {
+                let mut modified = combinations;
+                modified.extend(combination.clone());
+                Ok(modified)
+            }
+            None => {
+                exist = false;
+                Ok(combination.clone())
+            }
+        },
+    )?;
+    if !exist {
+        count_player_by_lottery(storage)
+            .update(&lottery_id.to_be_bytes(), |exists| match exists {
+                None => Ok(Uint128(1)),
+                Some(p) => Ok(p.add(Uint128(1))),
+            })
+            .map(|_| ())?
+    }
+    count_total_ticket_by_lottery(storage)
+        .update(&lottery_id.to_be_bytes(), |exists| match exists {
+            None => Ok(Uint128(combination.len() as u128)),
+            Some(p) => Ok(p.add(Uint128(combination.len() as u128))),
+        })
+        .map(|_| ())
 }
 
 pub fn user_combination_bucket<T: Storage>(
@@ -63,16 +148,22 @@ pub fn user_combination_bucket_read<T: Storage>(
     ReadonlyBucket::multilevel(&[COMBINATION_KEY, &lottery_id.to_be_bytes()], storage)
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct WinnerRewardClaims {
-    pub claimed: bool,
-    pub ranks: Vec<u8>,
+// index: lottery_id | count
+pub fn count_player_by_lottery<T: Storage>(storage: &mut T) -> Bucket<T, Uint128> {
+    bucket(PLAYER_COUNT_KEY, storage)
+}
+// index: lottery_id | count
+pub fn count_player_by_lottery_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, Uint128> {
+    bucket_read(PLAYER_COUNT_KEY, storage)
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct RewardClaim {
-    pub rank: u8,
-    pub claimed: bool,
+// index: lottery_id | count
+pub fn count_total_ticket_by_lottery<T: Storage>(storage: &mut T) -> Bucket<T, Uint128> {
+    bucket(TICKET_COUNT_KEY, storage)
+}
+// index: lottery_id | count
+pub fn count_total_ticket_by_lottery_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, Uint128> {
+    bucket_read(TICKET_COUNT_KEY, storage)
 }
 
 // if an address won a lottery in this round, saved by rank
@@ -146,64 +237,12 @@ pub fn winner_count_by_rank<T: Storage>(storage: &mut T, lottery_id: u64) -> Buc
     Bucket::multilevel(&[WINNER_RANK_KEY, &lottery_id.to_be_bytes()], storage)
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub enum PollStatus {
-    InProgress,
-    Passed,
-    Rejected,
-    RejectedByCreator,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub enum Proposal {
-    LotteryEveryBlockTime,
-    HolderFeePercentage,
-    DrandWorkerFeePercentage,
-    PrizePerRank,
-    JackpotRewardPercentage,
-    AmountToRegister,
-    SecurityMigration,
-    DaoFunding,
-    StakingContractMigration,
-    // test purpose
-    NotExist,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PollVoters {
-    pub voter: CanonicalAddr,
-    pub vote: bool,
-    pub weight: Uint128,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct PollInfoState {
-    pub creator: CanonicalAddr,
-    pub status: PollStatus,
-    pub end_height: u64,
-    pub start_height: u64,
-    pub description: String,
-    pub weight_yes_vote: Uint128,
-    pub weight_no_vote: Uint128,
-    pub yes_vote: u64,
-    pub no_vote: u64,
-    pub amount: Uint128,
-    pub prize_rank: Vec<u8>,
-    pub proposal: Proposal,
-    pub migration_address: Option<HumanAddr>,
-}
-
 pub fn poll_storage<T: Storage>(storage: &mut T) -> Bucket<T, PollInfoState> {
     bucket(POLL_KEY, storage)
 }
 
 pub fn poll_storage_read<T: Storage>(storage: &T) -> ReadonlyBucket<T, PollInfoState> {
     bucket_read(POLL_KEY, storage)
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct UserInfoState {
-    pub voted: Vec<u64>,
 }
 
 // poll vote storage index = VOTE_KEY:poll_id:address -> bool

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,7 +38,6 @@ pub struct State {
     pub loterra_cw20_contract_address: CanonicalAddr,
     pub loterra_staking_contract_address: CanonicalAddr,
     pub safe_lock: bool,
-    pub latest_winning_number: String,
     pub lottery_counter: u64,
     pub holders_bonus_block_time_end: u64,
 }


### PR DESCRIPTION
Added a list of improvement and a minor issue fix when claiming 

CHANGED
- Payout logic now every time winners collect stakers get rewards
- Register now accept vec of combinations and optional address
- Collect now accept optional address
- Vote can now be immediately presented if > 50% weight of all stakers voted
- DAO query his own balance rather than fixed state balance
- Jackpot rewards are now queried from the bucket jackpot

ADDED
- Count total players per lottery id
- Count total ticket played per lottery id
- Count total winners per ranks and lottery id
- Query winning combination per lottery id
- Query all jackpot per lottery id
- Bonus  holder will earn 50% of all collecting fees for compensation until condition block time reached to set it back to 20%
- Poll survey allow voting for decision that need off chain
- Query all players
 
FIXED
- Claim will not anymore charge fees for trx if no winning combination found
- Proposal DaoFunding could be stuck in pending forever if no funds now it will be rejected

REMOVED
- Public sale
- Jackpot rewards from state
- Last winning hash from state